### PR TITLE
fix: remove es5 as a target

### DIFF
--- a/src/components/lingo-game.tsx
+++ b/src/components/lingo-game.tsx
@@ -50,13 +50,14 @@ export function LingoGame() {
     if (!game.gameId) return
 
     sessionInfo.refetch().then(() => {
-      lingoSpring.x.set(LEFT_X)
-      lingoSpring.opacity.set(0)
-      lingoSpring.x.start(0)
-      lingoSpring.opacity.start(1)
       lingoSpringApi.set({
         x: LEFT_X,
         opacity: 0,
+      })
+
+      lingoSpringApi.start({
+        x: 0,
+        opacity: 1,
       })
     })
   }, [game.gameId])

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
remove es5 as a target (accidentally broke drizzle, oops)

next was being dumb at some point and I probably added it in when i was tired at 4 am

in the midst of being half-awake i also wrote in code that i forgot to finish, leading to the game element to not animate into the page as it's supposed to